### PR TITLE
Handle publications returning an empty array

### DIFF
--- a/publication-collector.js
+++ b/publication-collector.js
@@ -117,7 +117,7 @@ export class PublicationCollector extends EventEmitter {
       this.error(new Error('PublicationCollector: Publish function can only return a Cursor or an array of Cursors'));
     }
 
-    if (cursors.length > 0) {
+    if (cursors.length > 0 || Array.isArray(res)) {
       try {
         // for each cursor we call _publishCursor method which starts observing the cursor and
         // publishes the results.

--- a/publication-collector.test.js
+++ b/publication-collector.test.js
@@ -183,7 +183,7 @@ describe('PublicationCollector', () => {
       const collector = new PublicationCollector();
 
       collector.collect('publicationReturningNothing', readyCallback);
-      assert.isTrue(readyCallback.notCalled);
+      assert.isTrue(readyCallback.calledOnce);
 
       done();
     });


### PR DESCRIPTION
Hello. This PR resolves https://github.com/johanbrook/meteor-publication-collector/issues/38. Right now the package never calls `ready` for publications that return empty arrays. This PR resolves the issue, while maintaining compatibility with the low level subscription API that is discussed here https://github.com/johanbrook/meteor-publication-collector/pull/29#issuecomment-310387935.

From the docs https://docs.meteor.com/api/pubsub.html#Meteor-publish:

```
// Sometimes publish a query, sometimes publish nothing.
Meteor.publish('secretData', function () {
  if (this.userId === 'superuser') {
    return SecretData.find();
  } else {
    // Declare that no data is being published. If you leave this line out,
    // Meteor will never consider the subscription ready because it thinks
    // you're using the `added/changed/removed` interface where you have to
    // explicitly call `this.ready`.
    return [];
  }
});
```

